### PR TITLE
Don't crash when loading empty files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function cacheify (db, cachee, hash) {
       db.get(hashed, function (err, transformed) {
         if (err) {
           var join = concat(function(d) {
+            d = d || ' '
             db.put(hashed, d)
             self.queue(d)
             self.queue(null)


### PR DESCRIPTION
It doesn't happen often, but this keeps cacheify more in line with Browserify's default behavior :)
