### PR TITLE
Fix example usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var cacheify = require('cacheify')
 
 ...
 
-var coffeeify = cacheify(coffeeify, db)
+var cachingCoffeeify = cacheify(coffeeify, db)
 
 ...
 


### PR DESCRIPTION
A little fix -  should be `var cachingCoffeeify` instead of `var coffeeify` .
